### PR TITLE
Update to the new version of geocoder-autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@sectorlabs/react-geocoder-autocomplete",
-  "version": "1.1.1-sl.2",
+  "name": "@sector-labs/react-geocoder-autocomplete",
+  "version": "1.1.1-sl.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3897,9 +3897,9 @@
       }
     },
     "@sector-labs/geocoder-autocomplete": {
-      "version": "1.2.1-sl.2",
-      "resolved": "https://registry.npmjs.org/@sector-labs/geocoder-autocomplete/-/geocoder-autocomplete-1.2.1-sl.2.tgz",
-      "integrity": "sha512-0YnY06EIEt1vwfu/tcLVqmYMK/Gmikw1v2i1jB7Q0JU4ndnQDeGOGurTRitpzTxaMy2Ut9znn+M0gNr07UJaKw=="
+      "version": "1.2.1-sl.3",
+      "resolved": "https://registry.npmjs.org/@sector-labs/geocoder-autocomplete/-/geocoder-autocomplete-1.2.1-sl.3.tgz",
+      "integrity": "sha512-Wj45sCfGmCFyz10f65Kklagmxr5IHXxZQq/iVb8UfrSJMITF+XZRXbTOuqlLLCj9aCH2duMalUgxEN9sQhAoAA=="
     },
     "@sinonjs/commons": {
       "version": "1.8.1",
@@ -16351,7 +16351,7 @@
     },
     "react": {
       "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "resolved": false,
       "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
       "dev": true,
       "requires": {
@@ -16591,7 +16591,7 @@
     },
     "react-dom": {
       "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
+      "resolved": false,
       "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
       "dev": true,
       "requires": {
@@ -16620,7 +16620,7 @@
     },
     "react-scripts": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.0.tgz",
+      "resolved": false,
       "integrity": "sha512-icJ/ctwV5XwITUOupBP9TUVGdWOqqZ0H08tbJ1kVC5VpNWYzEZ3e/x8axhV15ZXRsixLo27snwQE7B6Zd9J2Tg==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sector-labs/react-geocoder-autocomplete",
-  "version": "1.1.1-sl.2",
+  "version": "1.1.1-sl.3",
   "description": "React component for the Geoapify Geocoder Autocomplete field",
   "author": {
     "name": "Geoapify GmbH",
@@ -47,7 +47,7 @@
   "peerDependencies": {
     "react": ">=17.0.1",
     "react-dom": ">=17.0.1",
-    "@sector-labs/geocoder-autocomplete": "^1.2.1-sl.2"
+    "@sector-labs/geocoder-autocomplete": "^1.2.1-sl.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",
@@ -78,6 +78,6 @@
     "dist"
   ],
   "dependencies": {
-    "@sector-labs/geocoder-autocomplete": "^1.2.1-sl.2"
+    "@sector-labs/geocoder-autocomplete": "^1.2.1-sl.3"
   }
 }


### PR DESCRIPTION
In order to add the new functionality and fix the small onBlur bug, update to the new version of @sector-labs/geocoder-autocomplete. 